### PR TITLE
Fix - store the unread tab marker when a title is auto-updating

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
  "short_name": "__MSG_extensionShortName__",
  "author": "__MSG_extensionAuthors__",
  "description": "__MSG_extensionDescription__",
- "version": "1.4",
+ "version": "1.5",
  "icons":
   {
    "48": "icons/unreadtab48.png",

--- a/opened.js
+++ b/opened.js
@@ -9,7 +9,7 @@ chrome.storage.sync.get
 
     var observer = new MutationObserver(function(mutations) {
       mutations.forEach(function(mutation) {
-        if (!document['isReadTab'] && !document.title.startsWith(prefix)) {
+        if (!document['isReadTab_kiUZ19'] && !document.title.startsWith(prefix)) {
           document.title = prefix + document.title;
         }
       });
@@ -19,7 +19,7 @@ chrome.storage.sync.get
     };
     observer.observe(target, config);
 
-    if (!document['isReadTab']) {
+    if (!document['isReadTab_kiUZ19']) {
       document.title = prefix + document.title;
     }
   }

--- a/opened.js
+++ b/opened.js
@@ -1,10 +1,26 @@
 chrome.storage.sync.get
- (
+(
   {'prefix': '• '},
   function(items)
-   {
+  {
+
+    var target = document.querySelector('title');
     var prefix = items.prefix;
-    var title = document.title;
-    if (title.substr(0, prefix.length) != prefix) document.title = prefix + document.title;
-   }
- );
+
+    var observer = new MutationObserver(function(mutations) {
+      mutations.forEach(function(mutation) {
+        if (!document['isReadTab'] && !document.title.startsWith(prefix)) {
+          document.title = prefix + document.title;
+        }
+      });
+    });
+    var config = {
+      childList: true,
+    };
+    observer.observe(target, config);
+
+    if (!document['isReadTab']) {
+      document.title = prefix + document.title;
+    }
+  }
+);

--- a/options.js
+++ b/options.js
@@ -10,7 +10,7 @@ for (i = 0; i < objects.length; i++)
 
 function loadOptions() {
   chrome.storage.sync.get(
-    {'prefix': '• '},
+    {'prefix': 'â€¢ '},
     function(items) {document.getElementById('prefix').value = items.prefix;}
   );
 };

--- a/visited.js
+++ b/visited.js
@@ -1,10 +1,13 @@
 chrome.storage.sync.get
- (
+(
   {'prefix': '• '},
   function(items)
-   {
+  {
     var prefix = items.prefix;
     var title = document.title;
-    if (title.substr(0, prefix.length) == prefix) document.title = title.substr(prefix.length, title.length);
-   }
- );
+    if (title.substr(0, prefix.length) == prefix) {
+      document.title = title.substr(prefix.length, title.length);
+      document['isReadTab'] = true;
+    }
+  }
+);

--- a/visited.js
+++ b/visited.js
@@ -5,9 +5,9 @@ chrome.storage.sync.get
   {
     var prefix = items.prefix;
     var title = document.title;
-    if (title.substr(0, prefix.length) == prefix) {
+    if (!document['isReadTab_kiUZ19'] && title.startsWith(prefix)) {
       document.title = title.substr(prefix.length, title.length);
-      document['isReadTab'] = true;
+      document['isReadTab_kiUZ19'] = true;
     }
   }
 );


### PR DESCRIPTION
Storing the unread tab marker when a title is auto-updating was fixed. This problem reproduced at YouTube.